### PR TITLE
sceneEngine.js: Introduce conditions & Refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ Scene defintion works with an array of objects.
 ```javascript
 const sceneDefinition = {
   controller: 'scene call item name',
-  scenes: [ // For each numeric state of the sceneItem one object.
-    { // Object for the value 1 of the sceneItem.
+  scenes: [ // For each numeric state of the controller Item one object.
+    { // Object for the value 1 of the controller Item.
       value: 1,
       targets: [ // Target states of items in the scene. Parameters explained later.
-        { item: 'Florian_Licht', value: 'ON', required: true },
+        { item: 'Florian_Licht', value: 'ON', required: true, conditionFn: function() { return parseFloat(items.getItem('Helligkeit').state) >= 10000; } },
         { item: 'Florian_LED_Stripes', value: 'OFF', required: false }
       ] 
     },
-    { // Object for the value 15 of the sceneItem.
+    { // Object for the value 15 of the controller Item.
       value: 15,
       targets: [ // Target states of items in the scene. Parameters explained later.
         { item: 'Florian_LED_Stripes', value: 'ON', required: true }
@@ -71,21 +71,16 @@ const sceneDefinition = {
   ]
 };
 ```
-__sceneTargets__' parameters
-Identifier | Purpose | Type | Required
--|-|-|-
-`item` | Name of a scene member. | String | yes
-`value` | Target state of that member. | String | yes
-`required` | Whether that member must match the target state when the scene is checked. | Boolean | no, defaults to true
+
+See [JSDoc: getSceneEngine()](https://florian-h05.github.io/openhab-js-tools/rulesx.html#.getSceneEngine) for documentation of parameters.
 
 ### Scene rule
 ```javascript
-rulesx.getSceneEngine(scenes, engineId);
+rulesx.getSceneEngine(sceneDefinition);
 ```
-Parameter | Purpose | required
--|-|-
-scenes | The scene definition array of objects. | yes
-engineId | The id of the scene engine, used in description. | yes
+| Parameter       | Purpose                                | Required |
+|-----------------|----------------------------------------|----------|
+| sceneDefinition | The scene definition array of objects. | yes      |
 
 ***
 ## Alarm Clock

--- a/README.md
+++ b/README.md
@@ -52,26 +52,24 @@ except to 0.
 ### Scene definition
 Scene defintion works with an array of objects.
 ```javascript
-const scenes = [ // For each sceneItem one object.
-  { // Object of the first sceneItem.
-    selectorItem: 'scene call item name',
-    selectorStates: [ // For each numeric state of the sceneItem one object.
-      { // Object for the value 1 of the sceneItem.
-        selectorValue: 1,
-        sceneTargets: [ // Target states of items in the scene. Parameters explained later.
-          { item: 'Florian_Licht', value: 'ON', required: true },
-          { item: 'Florian_LED_Stripes', value: 'OFF', required: false }
-        ] 
-      },
-      { // Object for the value 15 of the sceneItem.
-        selectorValue: 15,
-        sceneTargets: [ // Target states of items in the scene. Parameters explained later.
-          { item: 'Florian_LED_Stripes', value: 'ON', required: true }
-        ]
-      }
-    ]
-  }
-];
+const sceneDefinition = {
+  controller: 'scene call item name',
+  scenes: [ // For each numeric state of the sceneItem one object.
+    { // Object for the value 1 of the sceneItem.
+      value: 1,
+      targets: [ // Target states of items in the scene. Parameters explained later.
+        { item: 'Florian_Licht', value: 'ON', required: true },
+        { item: 'Florian_LED_Stripes', value: 'OFF', required: false }
+      ] 
+    },
+    { // Object for the value 15 of the sceneItem.
+      value: 15,
+      targets: [ // Target states of items in the scene. Parameters explained later.
+        { item: 'Florian_LED_Stripes', value: 'ON', required: true }
+      ]
+    }
+  ]
+};
 ```
 __sceneTargets__' parameters
 Identifier | Purpose | Type | Required

--- a/src/itemutils/dimmer.js
+++ b/src/itemutils/dimmer.js
@@ -30,13 +30,13 @@ const logger = log('org.openhab.automation.js.openhab-tools.itemutils.dimmer');
 const dimmer = (managerID, targetItem, targetState, step, time, ignoreExternalChange = false, overwrite = false) => {
   const CACHE_KEY = managerID;
   // Check Item and parameters.
-  if (!typeof managerID == 'string') throw Error('managerID must be a string.');
+  if (typeof managerID !== 'string') throw Error('managerID must be a string.');
   const item = items.getItem(targetItem);
   if (!item.rawState.floatValue) throw Error('targetItem must support float states.');
-  if (!typeof targetState == 'number') throw Error('targetState must be a number.');
-  if (!typeof step == 'number') throw Error('step must be a number.');
-  if (!typeof time == 'number') throw Error('time must be a number.');
-  
+  if (typeof targetState !== 'number') throw Error('targetState must be a number.');
+  if (typeof step !== 'number') throw Error('step must be a number.');
+  if (typeof time !== 'number') throw Error('time must be a number.');
+
   // If targetState already met, do not create a dimmer.
   let state = parseFloat(item.state);
   if (state === targetState) {

--- a/src/rules/sceneEngine.js
+++ b/src/rules/sceneEngine.js
@@ -24,12 +24,14 @@ class SceneEngine {
    * @param {String} engineId id of this instance
    * @hideconstructor
    */
-  constructor (sceneDefinition, engineId) {
-    if (typeof sceneDefinition === 'undefined') {
-      logger.error('Supplied scenes are undefined');
+  constructor (sceneDefinition) {
+    if (typeof sceneDefinition.selectorItem !== 'string') {
+      throw Error('selectorItem is not supplied or is not string!')
+    }
+    if (typeof sceneDefinition.selectorState !== 'object') {
+      throw Error('selectorValues is not an Array!')
     }
     this.scenes = sceneDefinition;
-    this.engineId = engineId;
   }
 
   /**
@@ -42,20 +44,16 @@ class SceneEngine {
   getTriggers () {
     const ruleTriggers = [];
     const updateTriggers = [];
-    // For each sceneSelector the selectorItem.
-    for (let i = 0; i < this.scenes.length; i++) {
-      const currentSelector = this.scenes[i];
-      logger.debug('Adding ItemCommandTrigger for [{}].', currentSelector.selectorItem);
-      ruleTriggers.push(triggers.ItemCommandTrigger(currentSelector.selectorItem));
-      // For each selectorState.
-      for (let j = 0; j < currentSelector.selectorStates.length; j++) {
-        const currentState = currentSelector.selectorStates[j];
-        // For for each sceneTarget, the member items that are required (default is required).
-        for (let k = 0; k < currentState.sceneTargets.length; k++) {
-          const target = currentState.sceneTargets[k];
-          if (target.required !== false && updateTriggers.indexOf(target.item) === -1) {
-            updateTriggers.push(target.item);
-          }
+    logger.debug('Adding ItemCommandTrigger for [{}].', this.scenes.selectorItem);
+    ruleTriggers.push(triggers.ItemCommandTrigger(this.scenes.selectorItem));
+    // For each selectorState.
+    for (let j = 0; j < this.scenes.selectorStates.length; j++) {
+       const currentState = this.scenes.selectorStates[j];
+      // For for each sceneTarget, the member items that are required (default is required).
+      for (let k = 0; k < currentState.sceneTargets.length; k++) {
+        const target = currentState.sceneTargets[k];
+        if (target.required !== false && updateTriggers.indexOf(target.item) === -1) {
+          updateTriggers.push(target.item);
         }
       }
     }
@@ -69,23 +67,18 @@ class SceneEngine {
   /**
    * Calls the scene. Sets the scene members to the given target state.
    * @private
-   * @param {String} triggerItem name of scene selector that received command
+   * @param {Number} sceneNumber value of selectorState / number of scene to call
    */
-  callScene (triggerItem) {
-    // Get the correct sceneSelector.
-    for (let curSelector = 0; curSelector < this.scenes.length; curSelector++) {
-      if (this.scenes[curSelector].selectorItem === triggerItem) {
-        // Get the correct selectorState.
-        for (let curState = 0; curState < this.scenes[curSelector].selectorStates.length; curState++) {
-          // Get the correct sceneTargets.
-          if (this.scenes[curSelector].selectorStates[curState].selectorValue === parseInt(items.getItem(triggerItem).state)) {
-            logger.info('Call scene: Found selectorState [{}] of sceneSelector [{}].', this.scenes[curSelector].selectorStates[curState].selectorValue, this.scenes[curSelector].selectorItem);
-            const targets = this.scenes[curSelector].selectorStates[curState].sceneTargets;
-            // Send commands to member items.
-            for (let curTarget = 0; curTarget < targets.length; curTarget++) {
-              items.getItem(targets[curTarget].item).sendCommand(targets[curTarget].value);
-            }
-          }
+  callScene (sceneNumber) {
+    // Get the correct selectorState.
+    for (let curState = 0; curState < this.scenes.selectorStates.length; curState++) {
+      // Get the correct sceneTargets.
+      if (this.scenes.selectorStates[curState].selectorValue === sceneNumber) {
+        logger.info('Call scene: Found selectorState [{}] of sceneSelector [{}].', this.scenes.selectorStates[curState].selectorValue, this.scenes.selectorItem);
+        const targets = this.scenes.selectorStates[curState].sceneTargets;
+        // Send commands to member items.
+        for (let curTarget = 0; curTarget < targets.length; curTarget++) {
+          items.getItem(targets[curTarget].item).sendCommand(targets[curTarget].value);
         }
       }
     }
@@ -96,42 +89,39 @@ class SceneEngine {
    * @private
    */
   checkScene () {
-    // Check each sceneSelector.
-    for (let curSelector = 0; curSelector < this.scenes.length; curSelector++) {
-      let selectorValueMatching = 0; // The selector value of the matching scene.
-      let sceneFound = false;
-      // Check each selectorState. The first one matching is used.
-      for (let curState = 0; curState < this.scenes[curSelector].selectorStates.length && sceneFound === false; curState++) {
-        let statesMatchingValue = true;
-        // Checks whether sceneTargets are matching. As soon as one is not matching it's target value, the next selector state is checked.
-        for (let curTarget = 0; curTarget < this.scenes[curSelector].selectorStates[curState].sceneTargets.length && statesMatchingValue === true; curTarget++) {
-          const target = this.scenes[curSelector].selectorStates[curState].sceneTargets[curTarget];
-          if (!(target.required === false)) {
-            const itemState = items.getItem(target.item).state.toString();
-            logger.debug('Check scene (selectorState [{}] of sceneSelector [{}]): Checking scene member [{}] with state [{}].', this.scenes[curSelector].selectorStates[curState].selectorValue, this.scenes[curSelector].selectorItem, target.item, itemState);
-            // Check whether the current item states does not match the target state.
-            if (!(
-              (itemState === target.value) ||
-               (itemState === '0' && target.value.toString().toUpperCase() === 'OFF') ||
-               (itemState === '100' && target.value.toString().toUpperCase() === 'ON') ||
-               (itemState === '0' && target.value.toString().toUpperCase() === 'UP') ||
-               (itemState === '100' && target.value.toString().toUpperCase() === 'DOWN')
-            )) {
-              statesMatchingValue = false;
-              logger.debug('Check scene (selectorState [{}] of sceneSelector [{}]): Scene member [{}] with state [{}] does not match [{}].', this.scenes[curSelector].selectorStates[curState].selectorValue, this.scenes[curSelector].selectorItem, target.item, itemState, target.value);
-            }
+    let selectorValueMatching = 0; // The selector value of the matching scene.
+    let sceneFound = false;
+    // Check each selectorState. The first one matching is used.
+    for (let curState = 0; curState < this.scenes.selectorStates.length && sceneFound === false; curState++) {
+      let statesMatchingValue = true;
+      // Checks whether sceneTargets are matching. As soon as one is not matching it's target value, the next selector state is checked.
+      for (let curTarget = 0; curTarget < this.scenes.selectorStates[curState].sceneTargets.length && statesMatchingValue === true; curTarget++) {
+        const target = this.scenes.selectorStates[curState].sceneTargets[curTarget];
+        if (!(target.required === false)) {
+          const itemState = items.getItem(target.item).state.toString();
+          logger.debug('Check scene (selectorState [{}] of sceneSelector [{}]): Checking scene member [{}] with state [{}].', this.scenes.selectorStates[curState].selectorValue, this.scenes.selectorItem, target.item, itemState);
+          // Check whether the current item states does not match the target state.
+          if (!(
+            (itemState === target.value) ||
+             (itemState === '0' && target.value.toString().toUpperCase() === 'OFF') ||
+             (itemState === '100' && target.value.toString().toUpperCase() === 'ON') ||
+             (itemState === '0' && target.value.toString().toUpperCase() === 'UP') ||
+             (itemState === '100' && target.value.toString().toUpperCase() === 'DOWN')
+          )) {
+            statesMatchingValue = false;
+            logger.debug('Check scene (selectorState [{}] of sceneSelector [{}]): Scene member [{}] with state [{}] does not match [{}].', this.scenes.selectorStates[curState].selectorValue, this.scenes.selectorItem, target.item, itemState, target.value);
           }
         }
-        // When all members match the target value
-        if (statesMatchingValue === true) {
-          logger.info('Check scene: Found matching selectorValue [{}] of sceneSelector [{}].', this.scenes[curSelector].selectorStates[curState].selectorValue, this.scenes[curSelector].selectorItem);
-          // Store the current selectorValue, that is matching all required targets.
-          selectorValueMatching = this.scenes[curSelector].selectorStates[curState].selectorValue;
-          sceneFound = true;
-        }
-        // Update sceneSelector.
-        items.getItem(this.scenes[curSelector].selectorItem).postUpdate(selectorValueMatching);
       }
+      // When all members match the target value
+      if (statesMatchingValue === true) {
+        logger.info('Check scene: Found matching selectorValue [{}] of sceneSelector [{}].', this.scenes.selectorStates[curState].selectorValue, this.scenes.selectorItem);
+        // Store the current selectorValue, that is matching all required targets.
+        selectorValueMatching = this.scenes.selectorStates[curState].selectorValue;
+        sceneFound = true;
+      }
+      // Update sceneSelector.
+      items.getItem(this.scenes.selectorItem).postUpdate(selectorValueMatching);
     }
   }
 
@@ -142,7 +132,7 @@ class SceneEngine {
    */
   getRule () {
     return rules.JSRule({
-      name: 'SceneEngine with id: ' + this.engineId,
+      name: 'SceneEngine for selectorItem' + this.scenes.selectorItem,
       description: 'Rule to run the SceneEngine.',
       triggers: this.getTriggers(),
       execute: event => {
@@ -162,14 +152,13 @@ class SceneEngine {
  * Provides the {@link rulesx.SceneEngine}.
  * @memberof rulesx
  * @param {*} scenes scenes definiton, have a look at the README
- * @param {String} engineId instance name
  * @returns {HostRule} SceneEngine rule
  *
  * @example
  * rulesx.getSceneEngine(scenes, engineId);
  */
-const getSceneEngine = (scenes, engineId) => {
-  return new SceneEngine(scenes, engineId).getRule();
+const getSceneEngine = (scenes) => {
+  return new SceneEngine(scenes).getRule();
 };
 
 module.exports = {

--- a/src/rules/sceneEngine.js
+++ b/src/rules/sceneEngine.js
@@ -113,19 +113,22 @@ class SceneEngine {
           let result = true;
           if (typeof target.conditionFn === 'function') {
             if (target.conditionFn() !== true) {
+              console.debug(`Check scene (value [${this.scenes[curState].value}] of controller [${this.controller}]): Scene member [${target.item}] with state [${itemState}] is not required to match as conditionFn did not return true.`);
               result = false;
             }
           }
+          if (result === true) {
           // Check whether the current Item state does not match the target state.
-          if (!(
-            (itemState === target.value) ||
+            if (!(
+              (itemState === target.value) ||
              (itemState === '0' && target.value.toString().toUpperCase() === 'OFF') ||
              (itemState === '100' && target.value.toString().toUpperCase() === 'ON') ||
              (itemState === '0' && target.value.toString().toUpperCase() === 'UP') ||
              (itemState === '100' && target.value.toString().toUpperCase() === 'DOWN')
-          ) || result !== true) { // Check whether conditionFn not returns true if conditionFn is defined.
-            statesMatchingValue = false;
-            console.debug(`Check scene (value [${this.scenes[curState].value}] of controller [${this.controller}]): Scene member [${target.item}] with state [${itemState}] does not match [${target.value}].`);
+            )) {
+              statesMatchingValue = false;
+              console.debug(`Check scene (value [${this.scenes[curState].value}] of controller [${this.controller}]): Scene member [${target.item}] with state [${itemState}] does not match [${target.value}] or is not required to match.`);
+            }
           }
         }
       }

--- a/src/rules/sceneEngine.js
+++ b/src/rules/sceneEngine.js
@@ -178,7 +178,7 @@ class SceneEngine {
  * @param {String} sceneDefinition.scenes[].targets[].item name of Item
  * @param {String} sceneDefinition.scenes[].targets[].value target state of Item
  * @param {Boolean} [sceneDefinition.scenes[].targets[].required=true] whether the Item's state must match the target state when the engine gets the current scene on change of a member
- * @param {Function} [sceneDefinition.scenes[].targets[].conditionFn] the Item is only commanded if the evaluation of this function returns true
+ * @param {Function} [sceneDefinition.scenes[].targets[].conditionFn] the Item is only commanded and required for scene checks if the evaluation of this function returns true
  * @returns {HostRule} SceneEngine rule
  */
 const getSceneEngine = (sceneDefinition) => {


### PR DESCRIPTION
## Additions
Introduce conditionFn which allows to use a expression to evaluate whether a scene target is valid now.

## Breaking Changes
- Create one scene engine rule per controller Item and not one rule for multiple (should increase performance as rule triggers are more fine grained).
- Refactoring/Renaming of the sceneDefinition.