### PR TITLE
alarmClock: Catch NaN for hour/minute

### DIFF
--- a/src/rules/alarmClock.js
+++ b/src/rules/alarmClock.js
@@ -19,15 +19,22 @@ const { ruleRegistry } = require('@runtime/RuleSupport');
  * Needs settings Items that must follow a given naming scheme.
  * The cron expression is build based on settings items.
  * When no day is selected, send command OFF to alarmSwitch and do not return rule.
+ * When hour/minute are NaN, return no rule and set them to defaults.
  * @memberof rulesx
  * @param {String} switchItem name of Item to switch the alarm on/off
  * @param {*} alarmFunc function to execute when the rule runs
  * @returns {(HostRule | null)} the alarm clock rule or null
  */
 function getClockRule (switchItem, alarmFunc) {
+  // If switchItem is OFF, return.
+  if (items.getItem(switchItem).state !== 'ON') return;
   // Get Items' states for time configuration.
   const hour = parseInt(items.getItem(switchItem + '_H').state);
   const minute = parseInt(items.getItem(switchItem + '_M').state);
+  // If hour or minute is NaN, return and initialize default values.
+  if (isNaN(hour) || isNaN(minute)) {
+    return;
+  }
   // Post time string.
   items.getItem(switchItem + '_Time').postUpdate(((hour < 10) ? '0' : '') + hour.toString() + ':' + ((minute < 10) ? '0' : '') + minute.toString());
   // Generate Array for days of week.
@@ -39,20 +46,18 @@ function getClockRule (switchItem, alarmFunc) {
   if (items.getItem(switchItem + '_FRI').state === 'ON') days.push('FRI');
   if (items.getItem(switchItem + '_SAT').state === 'ON') days.push('SAT');
   if (items.getItem(switchItem + '_SUN').state === 'ON') days.push('SUN');
-  // If no days is selected, turn of the switchItem.
-  if (days.length === 0) { items.getItem(switchItem).sendCommand('OFF'); }
+  // If no day is selected, return and turn of the switchItem.
+  if (days.length === 0) return items.getItem(switchItem).sendCommand('OFF');
   // Generate the QUARTZ cron expression.
-  const quartz = '0 ' + parseInt(minute) + ' ' + parseInt(hour) + ' ? * ' + days.join(',') + ' *';
+  const quartz = '0 ' + minute + ' ' + hour + ' ? * ' + days.join(',') + ' *';
   // Return the JSRule.
-  if (items.getItem(switchItem).state === 'ON') {
-    return rules.JSRule({
-      name: 'Alarm Clock ' + switchItem,
-      description: 'The Alarm Clock itself.',
-      triggers: [triggers.GenericCronTrigger(quartz)],
-      execute: alarmFunc,
-      id: switchItem
-    });
-  }
+  return rules.JSRule({
+    name: 'Alarm Clock ' + switchItem,
+    description: 'The Alarm Clock itself.',
+    triggers: [triggers.GenericCronTrigger(quartz)],
+    execute: alarmFunc,
+    id: switchItem
+  });
 }
 
 /**
@@ -83,8 +88,8 @@ function getAlarmClock (switchItem, alarmFunc) {
         triggers.ItemStateChangeTrigger(switchItem + '_SAT'),
         triggers.ItemStateChangeTrigger(switchItem + '_SUN')
       ],
-      execute: event => {
-        // As far as openHAB stable relies uses openhab-js 1.2.2, rules.removeRule(id) can be used.
+      execute: (event) => {
+        // As soon as openHAB stable uses openhab-js 1.2.2, rules.removeRule(id) can be used.
         if (!(ruleRegistry.get(switchItem) == null)) {
           ruleRegistry.remove(switchItem);
           logger.info('Removing rule: Alarm Clock {}', switchItem);

--- a/src/rules/alarmClock.js
+++ b/src/rules/alarmClock.js
@@ -9,7 +9,6 @@
  */
 
 const { items, rules, triggers } = require('openhab');
-const logger = require('openhab').log('org.openhab.automation.js.openhab-tools.rulesx.AlarmClock');
 const { ruleRegistry } = require('@runtime/RuleSupport');
 
 /**
@@ -33,6 +32,9 @@ function getClockRule (switchItem, alarmFunc) {
   const minute = parseInt(items.getItem(switchItem + '_M').state);
   // If hour or minute is NaN, return and initialize default values.
   if (isNaN(hour) || isNaN(minute)) {
+    items.getItem(switchItem + '_H').postUpdate('7');
+    items.getItem(switchItem + '_M').postUpdate('0');
+    items.getItem(switchItem + '_Time').postUpdate('07:00');
     return;
   }
   // Post time string.
@@ -92,7 +94,7 @@ function getAlarmClock (switchItem, alarmFunc) {
         // As soon as openHAB stable uses openhab-js 1.2.2, rules.removeRule(id) can be used.
         if (!(ruleRegistry.get(switchItem) == null)) {
           ruleRegistry.remove(switchItem);
-          logger.info('Removing rule: Alarm Clock {}', switchItem);
+          console.info('Removing rule: Alarm Clock {}', switchItem);
         }
         getClockRule(switchItem, alarmFunc);
       }


### PR DESCRIPTION
Fixes #9 where uninitialised hour/minute Items were parsed as `NaN` in the cron expression and led to errors in openhab-core.

Initialises hour/minute in case their are `NaN` with default value.

Additional refactorings were made.